### PR TITLE
PRE-1507 - feature/disable-pdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Traefik Mesh
 
+_NOTE: This is project is forked from https://github.com/traefik/mesh-helm-chart in order to add the ability to disable PodDisruptionBudgets. It is not intended to be maintained and we hope to migrate back to the main repository once this feature is pulled in._ 
+
 Traefik Mesh is a simple, yet full-featured service mesh. It is container-native and fits as your de-facto service mesh in your Kubernetes cluster.
 It supports the latest Service Mesh Interface specification [SMI](https://smi-spec.io/) that facilitates integration with pre-existing solution.
 

--- a/mesh/Chart.yaml
+++ b/mesh/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik-mesh
-version: 4.1.1
+version: 4.1.1-gs
 appVersion: v1.4.8
 description: Traefik Mesh - Simpler Service Mesh
 type: application

--- a/mesh/templates/controller/controller-pdb.yaml
+++ b/mesh/templates/controller/controller-pdb.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -17,3 +18,4 @@ spec:
       app: maesh
       component: controller
       release: {{ .Release.Name | quote }}
+{{ end }}

--- a/mesh/values.yaml
+++ b/mesh/values.yaml
@@ -206,3 +206,9 @@ metrics:
     # pushInterval: 10s
     # (Optional)
     # prefix: traefik
+
+# 
+# Pod Disruption Budget configuration.
+#
+pdb:
+  enabled: true


### PR DESCRIPTION
This is to add functionality to enable disabling PodDisruptionBudgets in the Traefik Mesh Helm Chart 

This has been forked from the main project and will be hosted here until either this is merged into upstream or the functionality is made available from the main project. 
This will be hosted on an addendum to the current version (4.1.1-gs). 
This has already been tested in the develop cluster and can replace the current setup for Traefik mesh 